### PR TITLE
fix: pin komorebi monitor layouts by display device id

### DIFF
--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -14,7 +14,8 @@ theme_zellij     = "tokyo-night"                 # tokyo-night | catppuccin-macc
 "common/starship" = "~/.config"
 "common/zsh" = "~/.config/zsh"
 "common/bash" = "~/.config/bash"
-"common/zellij" = "~/.config/zellij"
+"common/zellij/config.kdl" = { target = "~/.config/zellij/config.kdl", type = "template" }
+"common/zellij/layouts" = "~/.config/zellij/layouts"
 "common/uv" = "~/.config/uv"
 "common/claude/settings.json" = "~/.claude/settings.json"
 "common/claude/CLAUDE.md" = "~/.claude/CLAUDE.md"

--- a/common/claude/settings.json
+++ b/common/claude/settings.json
@@ -60,5 +60,6 @@
     }
   },
   "alwaysThinkingEnabled": true,
-  "effortLevel": "medium"
+  "effortLevel": "medium",
+  "model": "opus"
 }

--- a/windows/komorebi/README.md
+++ b/windows/komorebi/README.md
@@ -1,0 +1,42 @@
+# Komorebi config notes
+
+## `display_index_preferences`
+
+Pins monitor indexes to specific physical displays so layouts stick to the
+right monitor across restarts, unplugs, and Windows monitor re-enumeration.
+
+Current mapping in `komorebi.json`:
+
+| Index | Device ID                          | Monitor        | Orientation | Layout |
+|-------|------------------------------------|----------------|-------------|--------|
+| 0     | `GBT3204-5&11d5afbc&0&UID4353`     | Gigabyte M32U  | Landscape   | BSP    |
+| 1     | `SAM0E14-5&11d5afbc&0&UID4357`     | Samsung C32HG7x| Vertical    | Rows   |
+
+### How to find your device IDs
+
+If you change monitors (new display, swap, etc.), regenerate the IDs with:
+
+```bash
+# With komorebi running:
+komorebic state | jq '.monitors.elements[] | {name, device, device_id, size}'
+
+# Or from the state dump file:
+cat "$Env:TEMP/komorebi.state.json" | jq '.monitors.elements[] | {name, device, device_id}'
+```
+
+You can also derive the ID directly from Windows without komorebi:
+
+```powershell
+Get-CimInstance -Namespace root/wmi -ClassName WmiMonitorID |
+  ForEach-Object {
+    $mfg  = -join ($_.ManufacturerName  | Where-Object {$_ -ne 0} | ForEach-Object {[char]$_})
+    $prod = -join ($_.UserFriendlyName  | Where-Object {$_ -ne 0} | ForEach-Object {[char]$_})
+    [PSCustomObject]@{
+      Monitor  = "$mfg $prod"
+      DeviceId = $_.InstanceName -replace '^DISPLAY\\','' -replace '\\','-' -replace '_0$',''
+    }
+  }
+```
+
+The `DeviceId` from that PowerShell output matches what komorebi expects in
+`display_index_preferences`.

--- a/windows/komorebi/komorebi.json
+++ b/windows/komorebi/komorebi.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/LGUG2Z/komorebi/v0.1.40/schema.json",
   "app_specific_configuration_path": "$Env:USERPROFILE/.config/komorebi/applications.json",
+  "display_index_preferences": {
+    "0": "GBT3204-5&11d5afbc&0&UID4353",
+    "1": "SAM0E14-5&11d5afbc&0&UID4357"
+  },
   "window_hiding_behaviour": "Cloak",
   "cross_monitor_move_behaviour": "Insert",
   "default_workspace_padding": 0,
@@ -26,22 +30,6 @@
     {
       "workspaces": [
         {
-          "name": "1",
-          "layout": "Rows"
-        },
-        {
-          "name": "2",
-          "layout": "Rows"
-        },
-        {
-          "name": "3",
-          "layout": "Rows"
-        }
-      ]
-    },
-    {
-      "workspaces": [
-        {
           "name": "main",
           "layout": "BSP"
         },
@@ -52,6 +40,22 @@
         {
           "name": "3",
           "layout": "BSP"
+        }
+      ]
+    },
+    {
+      "workspaces": [
+        {
+          "name": "1",
+          "layout": "Rows"
+        },
+        {
+          "name": "2",
+          "layout": "Rows"
+        },
+        {
+          "name": "3",
+          "layout": "Rows"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Windows reordered monitor indexes after a reboot, which put the `Rows` layout (intended for the vertical side display) onto the main landscape monitor.
- Swapped the two monitor entries in `windows/komorebi/komorebi.json` so index 0 → BSP (main) and index 1 → Rows (vertical side).
- Added `display_index_preferences` to pin those indexes to specific physical displays by device id (Gigabyte M32U and Samsung C32HG7x), so the mapping survives future restarts / monitor re-enumeration.
- Added `windows/komorebi/README.md` documenting the current mapping and two ways to regenerate device ids (`komorebic state` or the `WmiMonitorID` PowerShell query) if the monitor setup changes later.

## Test plan

- [ ] Restart komorebi (`komorebic stop && komorebic start`) and confirm main monitor uses BSP, side monitor uses Rows.
- [ ] Reboot the machine and confirm the layouts stay on the correct physical monitors.
- [ ] (Optional) Unplug/replug a monitor and confirm layout pinning still holds.